### PR TITLE
mysql config params overrides top level params

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,9 +1,6 @@
 # Class: dcm4chee::config: See README.md for documentation.
 class dcm4chee::config () {
   class { 'dcm4chee::config::mysql':
-    database_name           => $::dcm4chee::database_name,
-    database_owner          => $::dcm4chee::database_owner,
-    database_owner_password => $::dcm4chee::database_owner_password,
   } ->
   class { 'dcm4chee::config::jboss':
     jboss_http_port          => $::dcm4chee::jboss_http_port,

--- a/manifests/config/mysql.pp
+++ b/manifests/config/mysql.pp
@@ -1,10 +1,9 @@
-class dcm4chee::config::mysql (
-  $database_name,
-  $database_owner,
-  $database_owner_password,
-  $database_host = 'localhost',
-  $database_port = 3306,
-) {
+class dcm4chee::config::mysql () {
+  $database_name = $::dcm4chee::database_name
+  $database_owner = $::dcm4chee::database_owner
+  $database_owner_password = $::dcm4chee::database_owner_password
+  $database_host = $::dcm4chee::database_host
+  $database_port = 3306
 
   $db_connection_file = 'pacs-mysql-ds.xml'
   $db_connection_file_path =


### PR DESCRIPTION
- since not all params where passed on to config::mysql
  host was wrong if set to something else than default localhost
- use top level parameters to render db connection settings
