### PR TITLE
jadd param server_host to set mysql grant

### DIFF
--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -4,7 +4,7 @@ class dcm4chee::database () {
   ::mysql::db { $::dcm4chee::database_name:
     user     => $::dcm4chee::database_owner,
     password => $::dcm4chee::database_owner_password,
-    host     => $::dcm4chee::database_host,
+    host     => $::dcm4chee::server_host,
     grant    => ['ALL'],
     sql      => "${::dcm4chee::sql_path}/create.mysql",
     require  => Staging::Deploy[$::dcm4chee::staging::dcm4chee_archive_name],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,7 @@
 # Class: dcm4chee: See README.md for documentation.
 class dcm4chee (
   $server                   = $::dcm4chee::params::server,
+  $server_host              = $::dcm4chee::params::server_host,
   $java_path                = $::dcm4chee::params::java_path,
   $user                     = $::dcm4chee::params::user,
   $user_home                = $::dcm4chee::params::user_home,
@@ -21,6 +22,7 @@ class dcm4chee (
   $tcp_port_min = 0
 
   validate_bool($server)
+  validate_string($server_host)
   validate_string($user)
   validate_absolute_path($user_home)
   validate_absolute_path($home_path)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@
 class dcm4chee::params {
 
   $server = true
+  $server_host = 'localhost'
   $java_path = undef
   $user = 'dcm4chee'
   $user_home = '/opt/dcm4chee/'

--- a/spec/classes/dcm4chee_database_spec.rb
+++ b/spec/classes/dcm4chee_database_spec.rb
@@ -21,5 +21,26 @@ describe 'dcm4chee::database', :type => :class do
     it { is_expected.to contain_mysql_database('pacsdb') }
     it { is_expected.to contain_mysql_user('dcm4chee@localhost') }
   end
+
+  describe 'when pacs server is on different host than database' do
+    let :pre_condition do
+      "class {'dcm4chee':
+         server      => false,
+         server_host => 'pacs.example.com',
+       }"
+    end
+
+    it { is_expected.to contain_mysql__db('pacsdb')
+      .with({
+        'user'     => 'dcm4chee',
+        'password' => 'dcm4chee',
+        'host'     => 'pacs.example.com',
+        'grant'    => ['ALL'],
+        'sql'      => "/opt/dcm4chee/staging/dcm4chee-2.18.0-mysql/sql//create.mysql",
+      }).that_requires('Staging::Deploy[dcm4chee-2.18.0-mysql.zip]')
+    }
+    it { is_expected.to contain_mysql_database('pacsdb') }
+    it { is_expected.to contain_mysql_user('dcm4chee@pacs.example.com') }
+  end
 end
 

--- a/spec/classes/dcm4chee_spec.rb
+++ b/spec/classes/dcm4chee_spec.rb
@@ -65,6 +65,14 @@ describe 'dcm4chee', :type => :class do
         end
         it { should_not compile }
       end
+      describe 'given non string server_host' do
+        let :params do
+          valid_required_params.merge({
+            :server_host => true,
+          })
+        end
+        it { should_not compile }
+      end
       describe 'given no java_path when server = true' do
         it { should_not compile }
       end


### PR DESCRIPTION
- is used to set the database grant to 'user'@'server_host'
- necessary if server and database are split to different nodes
