### PR TITLE
use top-level scoped variable notation

### DIFF
--- a/manifests/config/jboss.pp
+++ b/manifests/config/jboss.pp
@@ -5,9 +5,9 @@ class dcm4chee::config::jboss () {
   $jboss_http_port = $::dcm4chee::server_http_port
   $jboss_ajp_connector_port = $::dcm4chee::server_ajp_connector_port
 
-  $jboss_server_web_deploy_path = "${::dcm4chee::server_deploy_path}jboss-web.deployer/"
+  $jboss_server_web_deploy_path = "${::dcm4chee::dcm4chee_server_deploy_path}jboss-web.deployer/"
   $jboss_server_xml_path = "${jboss_server_web_deploy_path}server.xml"
-  $jboss_run_conf_path = "${::dcm4chee::bin_path}run.conf"
+  $jboss_run_conf_path = "${::dcm4chee::dcm4chee_bin_path}run.conf"
 
   file { $jboss_server_xml_path:
     ensure  => file,

--- a/manifests/config/mysql.pp
+++ b/manifests/config/mysql.pp
@@ -7,7 +7,7 @@ class dcm4chee::config::mysql () {
 
   $db_connection_file = 'pacs-mysql-ds.xml'
   $db_connection_file_path =
-  "${::dcm4chee::server_deploy_path}${db_connection_file}"
+  "${::dcm4chee::dcm4chee_server_deploy_path}${db_connection_file}"
 
   file { $db_connection_file_path:
     ensure  => file,

--- a/manifests/config/weasis.pp
+++ b/manifests/config/weasis.pp
@@ -10,7 +10,7 @@ class dcm4chee::config::weasis (
 
   $weasis_connector_file = 'weasis-connector.properties'
   $weasis_connector_file_path =
-  "${::dcm4chee::server_conf_path}${weasis_connector_file}"
+  "${::dcm4chee::dcm4chee_server_conf_path}${weasis_connector_file}"
 
   file { $weasis_connector_file_path:
     ensure  => file,

--- a/manifests/database.pp
+++ b/manifests/database.pp
@@ -6,7 +6,7 @@ class dcm4chee::database () {
     password => $::dcm4chee::database_owner_password,
     host     => $::dcm4chee::server_host,
     grant    => ['ALL'],
-    sql      => "${::dcm4chee::sql_path}/create.mysql",
+    sql      => "${::dcm4chee::dcm4chee_sql_path}/create.mysql",
     require  => Staging::Deploy[$::dcm4chee::staging::dcm4chee_archive_name],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,23 +42,24 @@ class dcm4chee (
     fail('server_java_path is undefined. needs to be defined if server = true')
   }
 
-  $archive_basename = "dcm4chee-${server_version}-mysql"
-  $home_path = "${user_home}${archive_basename}/"
-  $staging_path = "${user_home}staging/"
-  $staging_home_path = "${staging_path}${archive_basename}/"
-
+  # Define archive name, jboss version and important relative paths
+  $dcm4chee_archive_basename = "dcm4chee-${server_version}-mysql"
   $jboss_version = '4.2.3.GA'
+  $dcm4chee_bin_rel_path = 'bin/'
+  $dcm4chee_sql_rel_path = 'sql/'
+  $dcm4chee_server_rel_path = 'server/default/'
+  $dcm4chee_server_deploy_rel_path = "${dcm4chee_server_rel_path}deploy/"
+  $dcm4chee_server_conf_rel_path = "${dcm4chee_server_rel_path}conf/"
 
-  $bin_rel_path = 'bin/'
-  $sql_rel_path = 'sql/'
-  $server_rel_path = 'server/default/'
-  $server_deploy_rel_path = "${server_rel_path}deploy/"
-  $server_conf_rel_path = "${server_rel_path}conf/"
+  # Construct main paths needed by staging, installation, configuration
+  $staging_path = "${user_home}staging/"
+  $staging_dcm4chee_home_path = "${staging_path}${dcm4chee_archive_basename}/"
 
-  $bin_path = "${home_path}${bin_rel_path}"
-  $sql_path = "${staging_home_path}${sql_rel_path}"
-  $server_deploy_path = "${home_path}${server_deploy_rel_path}"
-  $server_conf_path = "${home_path}${server_conf_rel_path}"
+  $dcm4chee_home_path = "${user_home}${dcm4chee_archive_basename}/"
+  $dcm4chee_bin_path = "${dcm4chee_home_path}${dcm4chee_bin_rel_path}"
+  $dcm4chee_sql_path = "${staging_dcm4chee_home_path}${dcm4chee_sql_rel_path}"
+  $dcm4chee_server_deploy_path = "${dcm4chee_home_path}${dcm4chee_server_deploy_rel_path}"
+  $dcm4chee_server_conf_path = "${dcm4chee_home_path}${dcm4chee_server_conf_rel_path}"
 
   user { $user:
     ensure     => present,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,8 @@
 # Class: dcm4chee::install: See README.md for documentation.
 class dcm4chee::install () {
 
-  file { $dcm4chee::home_path:
-    source  => $dcm4chee::staging_home_path,
+  file { $::dcm4chee::dcm4chee_home_path:
+    source  => $::dcm4chee::staging_dcm4chee_home_path,
     recurse => true,
   }
 }

--- a/manifests/staging.pp
+++ b/manifests/staging.pp
@@ -1,30 +1,32 @@
 # Class: dcm4chee::staging: See README.md for documentation.
+# Prepares a staging directory with all archives, files in place
+# so installation only copies staging directory to its final destination
 class dcm4chee::staging () {
-  $dcm4chee_home_path = "${dcm4chee::staging_path}${dcm4chee::archive_basename}/"
-  $dcm4chee_bin_path = "${dcm4chee_home_path}${dcm4chee::bin_rel_path}"
+  $dcm4chee_home_path = $::dcm4chee::staging_dcm4chee_home_path
+  $dcm4chee_bin_path = "${dcm4chee_home_path}${::dcm4chee::dcm4chee_bin_rel_path}"
   $dcm4chee_deploy_path =
-  "${dcm4chee_home_path}${dcm4chee::server_deploy_rel_path}"
+  "${dcm4chee_home_path}${::dcm4chee::dcm4chee_server_deploy_rel_path}"
 
-  $jboss_extract_path = "${dcm4chee::staging_path}jboss-${dcm4chee::jboss_version}/"
+  $jboss_extract_path = "${::dcm4chee::staging_path}jboss-${::dcm4chee::jboss_version}/"
 
-  $dcm4chee_archive_name = "${dcm4chee::archive_basename}.zip"
+  $dcm4chee_archive_name = "${::dcm4chee::dcm4chee_archive_basename}.zip"
   $dcm4chee_base_url = 'http://sourceforge.net/projects/dcm4che/files/dcm4chee/'
-  $dcm4chee_source_url = "${dcm4chee_base_url}${dcm4chee::server_version}/${dcm4chee_archive_name}/download"
+  $dcm4chee_source_url = "${dcm4chee_base_url}${::dcm4chee::server_version}/${dcm4chee_archive_name}/download"
 
   include '::staging'
 
-  file { $dcm4chee::staging_path:
+  file { $::dcm4chee::staging_path:
     ensure => directory,
-    owner  => $dcm4chee::user,
-    group  => $dcm4chee::user,
+    owner  => $::dcm4chee::user,
+    group  => $::dcm4chee::user,
   }
 
   staging::deploy { $dcm4chee_archive_name:
     source  => $dcm4chee_source_url,
-    target  => $dcm4chee::staging_path,
-    user    => $dcm4chee::user,
-    group   => $dcm4chee::user,
-    require => File[$dcm4chee::staging_path],
+    target  => $::dcm4chee::staging_path,
+    user    => $::dcm4chee::user,
+    group   => $::dcm4chee::user,
+    require => File[$::dcm4chee::staging_path],
   }
 
   if $::dcm4chee::server {
@@ -33,12 +35,12 @@ class dcm4chee::staging () {
     }
 
     class { 'dcm4chee::staging::jboss':
-      require => File[$dcm4chee::staging_path],
+      require => File[$::dcm4chee::staging_path],
     }
 
     exec { "${dcm4chee_bin_path}install_jboss.sh":
-      cwd     => $dcm4chee::staging_path,
-      user    => $dcm4chee::user,
+      cwd     => $::dcm4chee::staging_path,
+      user    => $::dcm4chee::user,
       command => "${dcm4chee_bin_path}install_jboss.sh ${jboss_extract_path}",
       require => [
         Staging::Deploy[$dcm4chee_archive_name],
@@ -47,7 +49,7 @@ class dcm4chee::staging () {
 
     file { "${dcm4chee_bin_path}run.sh":
       ensure  => present,
-      owner   => $dcm4chee::user,
+      owner   => $::dcm4chee::user,
       source  => "${jboss_extract_path}bin/run.sh",
       require => Exec["${dcm4chee_bin_path}install_jboss.sh"],
     }


### PR DESCRIPTION
- make init path variable names more explicit
