### PR TITLE
add unless command to install_jboss.sh exec

### DIFF
--- a/files/validate_dcm4chee_jboss_installed.sh
+++ b/files/validate_dcm4chee_jboss_installed.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# usage is: validate_dcm4chee_jboss_installed.sh <path-to-dcm4chee-home>
+
+DCM4CHEE_HOME=$1
+if [ -z $DCM4CHEE_HOME ]; then
+    echo 'DCM4CHEE_HOME not specified'
+    exit 2
+fi
+
+DCM4CHEE_BIN="${DCM4CHEE_HOME}/bin"
+
+if [ -f "${DCM4CHEE_BIN}/run.jar" ]; then
+    echo "jboss installed"
+    exit 0
+else
+    echo "jboss not installed"
+    exit 1
+fi
+

--- a/spec/classes/dcm4chee_staging_spec.rb
+++ b/spec/classes/dcm4chee_staging_spec.rb
@@ -34,9 +34,26 @@ describe 'dcm4chee::staging', :type => :class do
       it { is_expected.to contain_class('dcm4chee::staging::jboss')
             .that_requires('File[/opt/dcm4chee/staging/]')
       }
+      it { is_expected.to contain_file('/usr/local/bin/validate_dcm4chee_jboss_installed.sh')
+        .with({
+          'ensure' => 'file',
+          'owner'  => 'root',
+          'group'  => 'root',
+          'mode'   => '0755',
+          'source' => 'puppet:///modules/dcm4chee/validate_dcm4chee_jboss_installed.sh',
+        })
+      }
       it { is_expected.to contain_exec("/opt/dcm4chee/staging/dcm4chee-2.18.0-#{database_type_short}/bin/install_jboss.sh")
-            .that_requires("Staging::Deploy[dcm4chee-2.18.0-#{database_type_short}.zip]")
-            .that_requires('Class[dcm4chee::staging::jboss]')
+        .with({
+          'unless'    => "/usr/local/bin/validate_dcm4chee_jboss_installed.sh /opt/dcm4chee/staging/dcm4chee-2.18.0-#{database_type_short}/",
+          'command'   => "/opt/dcm4chee/staging/dcm4chee-2.18.0-#{database_type_short}/bin/install_jboss.sh /opt/dcm4chee/staging/jboss-4.2.3.GA/",
+          'cwd'       => '/opt/dcm4chee/staging/',
+          'user'      => 'dcm4chee',
+          'path'      => '/bin:/usr/bin:/usr/local/bin',
+        })
+        .that_requires("Staging::Deploy[dcm4chee-2.18.0-#{database_type_short}.zip]")
+        .that_requires('Class[dcm4chee::staging::jboss]')
+        .that_requires('File[/usr/local/bin/validate_dcm4chee_jboss_installed.sh]')
       }
       it { is_expected.to contain_file("/opt/dcm4chee/staging/dcm4chee-2.18.0-#{database_type_short}/bin/run.sh")
             .with({


### PR DESCRIPTION
- prevents staging from executing install_jboss.sh
  if run.jar is already found in staging's dcm4chee_home/bin
- comment about jboss run.sh bug
