### PR TITLE
add dicom_webviewer_hosts_allow parameter

### DIFF
--- a/manifests/config/weasis.pp
+++ b/manifests/config/weasis.pp
@@ -1,9 +1,10 @@
+# Class: dcm4chee::config::weasis. See README.md for documentation.
 class dcm4chee::config::weasis () {
 
-  $weasis_aet = $::dcm4chee::server_dicom_aet
-  $weasis_host = $::dcm4chee::server_host
-  $weasis_port = $::dcm4chee::server_dicom_port
-  $weasis_hosts_allow = $::dcm4chee::weasis_host_allow
+  $pacs_host = $::dcm4chee::server_host
+  $pacs_aet = $::dcm4chee::server_dicom_aet
+  $pacs_port = $::dcm4chee::server_dicom_port
+  $weasis_hosts_allow = $::dcm4chee::dicom_webviewer_hosts_allow
 
   $weasis_connector_file = 'weasis-connector.properties'
   $weasis_connector_file_path =

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,23 +1,24 @@
 # Class: dcm4chee: See README.md for documentation.
 class dcm4chee (
-  $server                    = $::dcm4chee::params::server,
-  $server_version            = $::dcm4chee::params::server_version,
-  $server_host               = $::dcm4chee::params::server_host,
-  $server_java_path          = $::dcm4chee::params::server_java_path,
-  $server_java_opts          = $::dcm4chee::params::server_java_opts,
-  $server_http_port          = $::dcm4chee::params::server_http_port,
-  $server_ajp_connector_port = $::dcm4chee::params::server_ajp_connector_port,
-  $server_dicom_aet          = $::dcm4chee::params::server_dicom_aet,
-  $server_dicom_port         = $::dcm4chee::params::server_dicom_port,
-  $user                      = $::dcm4chee::params::user,
-  $user_home                 = $::dcm4chee::params::user_home,
-  $database                  = $::dcm4chee::params::database,
-  $database_type             = $::dcm4chee::params::database_type,
-  $database_host             = $::dcm4chee::params::database_host,
-  $database_port             = $::dcm4chee::params::database_port,
-  $database_name             = $::dcm4chee::params::database_name,
-  $database_owner_password   = $::dcm4chee::params::database_owner_password,
-  $dicom_webviewer           = $::dcm4chee::params::dicom_webviewer,
+  $server                      = $::dcm4chee::params::server,
+  $server_version              = $::dcm4chee::params::server_version,
+  $server_host                 = $::dcm4chee::params::server_host,
+  $server_java_path            = $::dcm4chee::params::server_java_path,
+  $server_java_opts            = $::dcm4chee::params::server_java_opts,
+  $server_http_port            = $::dcm4chee::params::server_http_port,
+  $server_ajp_connector_port   = $::dcm4chee::params::server_ajp_connector_port,
+  $server_dicom_aet            = $::dcm4chee::params::server_dicom_aet,
+  $server_dicom_port           = $::dcm4chee::params::server_dicom_port,
+  $user                        = $::dcm4chee::params::user,
+  $user_home                   = $::dcm4chee::params::user_home,
+  $database                    = $::dcm4chee::params::database,
+  $database_type               = $::dcm4chee::params::database_type,
+  $database_host               = $::dcm4chee::params::database_host,
+  $database_port               = $::dcm4chee::params::database_port,
+  $database_name               = $::dcm4chee::params::database_name,
+  $database_owner_password     = $::dcm4chee::params::database_owner_password,
+  $dicom_webviewer             = $::dcm4chee::params::dicom_webviewer,
+  $dicom_webviewer_hosts_allow = $::dcm4chee::params::dicom_webviewer_hosts_allow,
 ) inherits dcm4chee::params {
 
   $tcp_port_max = 65535
@@ -47,6 +48,7 @@ class dcm4chee (
   validate_string($database_name)
   validate_string($database_owner_password)
   validate_bool($dicom_webviewer)
+  validate_string($dicom_webviewer_hosts_allow)
 
   if ($server == false and $database == false) {
     fail('server and database cannot both be false')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class dcm4chee::params {
   $database_name = 'pacsdb'
   $database_owner_password = 'dcm4chee'
   $dicom_webviewer = true
+  $dicom_webviewer_hosts_allow = undef
   
   if !($::operatingsystem == 'Ubuntu' and $::operatingsystemrelease == '14.04'
   and $::architecture == 'amd64') {

--- a/spec/classes/dcm4chee_config_weasis_spec.rb
+++ b/spec/classes/dcm4chee_config_weasis_spec.rb
@@ -18,6 +18,36 @@ describe 'dcm4chee::config::weasis', :type => :class do
               'group'   => 'dcm4chee',
               'mode'    => '0644',
             })
+            .with_content(/^pacs.aet=DCM4CHEE$/)
+            .with_content(/^pacs.host=localhost$/)
+            .with_content(/^pacs.port=11112$/)
+            .with_content(/^hosts.allow=$/)
+      }
+    end
+
+    describe "with database_type=#{database_type} and custom server parameters" do
+      let :pre_condition do
+        "class {'dcm4chee':
+           database_type               => #{database_type},
+           server_java_path            => '/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java',
+           server_host                 => '192.168.1.11',
+           server_dicom_aet            => 'MEDPACS',
+           server_dicom_port           => '104',
+           dicom_webviewer_hosts_allow => '192.168.1.20,192.168.1.21'
+        }"
+      end
+
+      it { is_expected.to contain_file("/opt/dcm4chee/dcm4chee-2.18.0-#{database_type_short}/server/default/conf/weasis-connector.properties")
+            .with({
+              'ensure'  => 'file',
+              'owner'   => 'dcm4chee',
+              'group'   => 'dcm4chee',
+              'mode'    => '0644',
+            })
+            .with_content(/^pacs.aet=MEDPACS$/)
+            .with_content(/^pacs.host=192.168.1.11$/)
+            .with_content(/^pacs.port=104$/)
+            .with_content(/^hosts.allow=192.168.1.20,192.168.1.21$/)
       }
     end
   end

--- a/spec/classes/dcm4chee_spec.rb
+++ b/spec/classes/dcm4chee_spec.rb
@@ -278,6 +278,14 @@ describe 'dcm4chee', :type => :class do
         end
         it { should_not compile }
       end
+      describe 'given non string dicom_webviewer_hosts_allow' do
+        let :params do
+          valid_required_params.merge({
+            :dicom_webviewer_hosts_allow => true,
+          })
+        end
+        it { should_not compile }
+      end
     end
   end
 

--- a/templates/dcm4chee_home/server/default/deploy/weasis-connector.properties.erb
+++ b/templates/dcm4chee_home/server/default/deploy/weasis-connector.properties.erb
@@ -50,9 +50,9 @@ weasis.base.url=${server.base.url}/weasis
 
 ##########  PACS properties ########## 
 # AET, hostname and port of the PACS
-pacs.aet=<%= @weasis_aet %>
-pacs.host=<%= @weasis_host %>
-pacs.port=<%= @weasis_port %>
+pacs.aet=<%= @pacs_aet %>
+pacs.host=<%= @pacs_host %>
+pacs.port=<%= @pacs_port %>
 ##### Encoding type of the values (ex. Patient name, Study description...)
 #pacs.db.encoding=utf-8
 


### PR DESCRIPTION
- used to configure hosts_allow property of weasis connector
- test weasis connection properties content
- rename local weasis config vars to pacs_aet,... since weasis prefix is
  misleading
