### PR TITLE
manage log4j appenders

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ Specifies the dcm4chee (jboss) log file path managing 'server/default/conf/jboss
 Valid options: integer.
 Defaults to '1'.
 
+##### `server_log_appenders`
+
+Specifies the dcm4chee (jboss) log appenders managing 'server/default/conf/jboss-log4j.xml' <root> <appender-ref> elements.
+Valid options: array containing elements from values 'FILE', 'CONSOLE', 'JMX'.
+Defaults to [ 'FILE', 'JMX' ].
+
 ##### `server_dicom_aet`
 
 Specifies the dcm4chee DICOM AE Title.

--- a/manifests/config/jboss.pp
+++ b/manifests/config/jboss.pp
@@ -32,6 +32,7 @@ class dcm4chee::config::jboss () {
   $jboss_log_file_path = $::dcm4chee::server_log_file_path
   $jboss_log_file_max_size = $::dcm4chee::server_log_file_max_size
   $jboss_log_max_backups = $::dcm4chee::server_log_max_backups
+  $jboss_log_appenders = $::dcm4chee::server_log_appenders
   file { "${::dcm4chee::dcm4chee_server_conf_path}jboss-log4j.xml":
     ensure  => file,
     owner   => $::dcm4chee::user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@ class dcm4chee (
   $server_log_file_path      = $::dcm4chee::params::server_log_file_path,
   $server_log_file_max_size  = $::dcm4chee::params::server_log_file_max_size,
   $server_log_max_backups    = $::dcm4chee::params::server_log_max_backups,
+  $server_log_appenders      = $::dcm4chee::params::server_log_appenders,
   $server_dicom_aet          = $::dcm4chee::params::server_dicom_aet,
   $server_dicom_port         = $::dcm4chee::params::server_dicom_port,
   $manage_user               = $::dcm4chee::params::manage_user,
@@ -40,6 +41,16 @@ class dcm4chee (
   validate_string($server_log_file_path)
   validate_string($server_log_file_max_size)
   validate_integer($server_log_max_backups)
+
+  # Only allow appenders which actually exist in jboss-log4j.xml
+  validate_array($server_log_appenders)
+  if empty($server_log_appenders) {
+    fail('server_log_appenders cannot be empty. Choose from values: FILE, CONSOLE, JMX')
+  }
+  if ! member(['FILE', 'CONSOLE', 'JMX'], $server_log_appenders) {
+    fail('server_log_appenders contains invalid members. Choose from values: FILE, CONSOLE, JMX')
+  }
+
   validate_string($server_dicom_aet)
   validate_integer($server_dicom_port, $tcp_port_max, $tcp_port_min)
   validate_bool($manage_user)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,10 @@ class dcm4chee::params {
   $server_log_file_path = '${jboss.server.log.dir}/server.log'
   $server_log_file_max_size = '10000KB'
   $server_log_max_backups  = '1'
+  $server_log_appenders  = [
+    'FILE',
+    'JMX',
+  ]
   $server_dicom_aet = 'DCM4CHEE'
   $server_dicom_port = '11112'
   $manage_user = true

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
   ],
   "description": "Module for dcm4chee pacs configuration",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.0 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"},
     {"name":"puppetlabs/mysql","version_requirement":">= 3.1.0 < 5.0.0"},
     {"name":"puppetlabs/postgresql","version_requirement":">= 4.0.0 < 5.0.0"},
     {"name":"nanliu/staging","version_requirement":">=1.0.3"}

--- a/spec/classes/dcm4chee_spec.rb
+++ b/spec/classes/dcm4chee_spec.rb
@@ -290,6 +290,30 @@ describe 'dcm4chee', :type => :class do
         end
         it { should_not compile }
       end
+      describe 'given non array server_log_appenders' do
+        let :params do
+          valid_required_params.merge({
+            :server_log_appenders => 'FILE, JMX',
+          })
+        end
+        it { should_not compile }
+      end
+      describe 'given empty array server_log_appenders' do
+        let :params do
+          valid_required_params.merge({
+            :server_log_appenders => [],
+          })
+        end
+        it { should_not compile }
+      end
+      describe 'given server_log_appenders with member other than FILE, CONSOLE, JMX' do
+        let :params do
+          valid_required_params.merge({
+            :server_log_appenders => [ 'FILE', 'JMX', 'TRUMPET' ],
+          })
+        end
+        it { should_not compile }
+      end
       describe 'given non string server_dicom_aet' do
         let :params do
           valid_required_params.merge({

--- a/templates/dcm4chee_home/server/default/conf/jboss-log4j.xml.erb
+++ b/templates/dcm4chee_home/server/default/conf/jboss-log4j.xml.erb
@@ -560,9 +560,9 @@
    <!-- ======================= -->
 
    <root>
-      <appender-ref ref="CONSOLE"/>
-      <appender-ref ref="FILE"/>
-      <appender-ref ref="JMX"/>
+   <% @jboss_log_appenders.each do |appender| -%>
+     <appender-ref ref="<%= appender %>"/>
+   <% end -%>
    </root>
 
    <!-- Clustering logging -->


### PR DESCRIPTION
- add array param server_log_appenders
- ensure array members are of FILE, CONSOLE, JMX
- upgrade puppetlabs-stdlib dependency to 4.5.0
  since we are using member() on array
