### PR TITLE
staging ensures files managed by config are absent

### DIFF
--- a/manifests/config/jboss.pp
+++ b/manifests/config/jboss.pp
@@ -3,11 +3,7 @@ class dcm4chee::config::jboss () {
   
   $jboss_http_port = $::dcm4chee::server_http_port
   $jboss_ajp_connector_port = $::dcm4chee::server_ajp_connector_port
-
-  $jboss_server_web_deploy_path = "${::dcm4chee::dcm4chee_server_deploy_path}jboss-web.deployer/"
-  $jboss_server_xml_path = "${jboss_server_web_deploy_path}server.xml"
-
-  file { $jboss_server_xml_path:
+  file { "${::dcm4chee::dcm4chee_server_deploy_path}jboss-web.deployer/server.xml":
     ensure  => file,
     owner   => $::dcm4chee::user,
     group   => $::dcm4chee::user,

--- a/manifests/staging.pp
+++ b/manifests/staging.pp
@@ -7,6 +7,8 @@ class dcm4chee::staging () {
   $dcm4chee_bin_path = "${dcm4chee_home_path}${::dcm4chee::dcm4chee_bin_rel_path}"
   $dcm4chee_deploy_path =
   "${dcm4chee_home_path}${::dcm4chee::dcm4chee_server_deploy_rel_path}"
+  $dcm4chee_server_conf_path =
+  "${dcm4chee_home_path}${::dcm4chee::dcm4chee_server_conf_rel_path}"
 
   $jboss_extract_path = "${::dcm4chee::staging_path}jboss-${::dcm4chee::jboss_version}/"
 
@@ -83,6 +85,22 @@ class dcm4chee::staging () {
       class { '::dcm4chee::staging::weasis':
         require => File["${dcm4chee_bin_path}run.sh"],
       }
+    }
+
+    # Important Note: hack to prevent dcm4chee::install
+    # from overriding dcm4chee::config's work
+    # which manages these files
+    $db_connection_file = $::dcm4chee::database_type ? {
+      'postgresql' => 'pacs-postgres-ds.xml',
+      'mysql'      => 'pacs-mysql-ds.xml',
+    }
+    file {[
+      "${dcm4chee_deploy_path}${db_connection_file}",
+      "${dcm4chee_deploy_path}jboss-web.deployer/server.xml",
+      "${dcm4chee_bin_path}run.conf",
+      "${dcm4chee_server_conf_path}jboss-log4j.xml",
+    ]:
+      ensure => absent,
     }
   }
 }

--- a/spec/classes/dcm4chee_staging_spec.rb
+++ b/spec/classes/dcm4chee_staging_spec.rb
@@ -2,7 +2,15 @@ require 'spec_helper'
 
 describe 'dcm4chee::staging', :type => :class do
 
-  { 'mysql' => 'mysql', 'postgresql' => 'psql' }.each do |database_type, database_type_short|
+  { 'mysql'      => {
+                      'type_short' => 'mysql',
+                      'configfile_short' => 'mysql'
+                    },
+    'postgresql' => {
+                      'type_short' => 'psql',
+                      'configfile_short' => 'postgres'
+                    },
+  }.each do |database_type, database|
     describe "with defaults, server_java_path set and database_type=#{database_type}" do
       let :pre_condition do
         "class {'dcm4chee':
@@ -19,9 +27,9 @@ describe 'dcm4chee::staging', :type => :class do
               'group'  => 'dcm4chee',
             })
       }
-      it { is_expected.to contain_staging__deploy("dcm4chee-2.18.1-#{database_type_short}.zip")
+      it { is_expected.to contain_staging__deploy("dcm4chee-2.18.1-#{database['type_short']}.zip")
             .with({
-              'source'  => "http://sourceforge.net/projects/dcm4che/files/dcm4chee/2.18.1/dcm4chee-2.18.1-#{database_type_short}.zip/download",
+              'source'  => "http://sourceforge.net/projects/dcm4che/files/dcm4chee/2.18.1/dcm4chee-2.18.1-#{database['type_short']}.zip/download",
               'target'  => '/opt/dcm4chee/staging/',
               'user'    => 'dcm4chee',
               'group'   => 'dcm4chee',
@@ -29,7 +37,7 @@ describe 'dcm4chee::staging', :type => :class do
             .that_requires('File[/opt/dcm4chee/staging/]')
       }
       it { is_expected.to contain_class('dcm4chee::staging::jai_imageio')
-            .that_requires("Staging::Deploy[dcm4chee-2.18.1-#{database_type_short}.zip]")
+            .that_requires("Staging::Deploy[dcm4chee-2.18.1-#{database['type_short']}.zip]")
       }
       it { is_expected.to contain_class('dcm4chee::staging::jboss')
             .that_requires('File[/opt/dcm4chee/staging/]')
@@ -43,29 +51,49 @@ describe 'dcm4chee::staging', :type => :class do
           'source' => 'puppet:///modules/dcm4chee/validate_dcm4chee_jboss_installed.sh',
         })
       }
-      it { is_expected.to contain_exec("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database_type_short}/bin/install_jboss.sh")
+      it { is_expected.to contain_exec("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/bin/install_jboss.sh")
         .with({
-          'unless'    => "/usr/local/bin/validate_dcm4chee_jboss_installed.sh /opt/dcm4chee/staging/dcm4chee-2.18.1-#{database_type_short}/",
-          'command'   => "/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database_type_short}/bin/install_jboss.sh /opt/dcm4chee/staging/jboss-4.2.3.GA/",
+          'unless'    => "/usr/local/bin/validate_dcm4chee_jboss_installed.sh /opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/",
+          'command'   => "/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/bin/install_jboss.sh /opt/dcm4chee/staging/jboss-4.2.3.GA/",
           'cwd'       => '/opt/dcm4chee/staging/',
           'user'      => 'dcm4chee',
           'path'      => '/bin:/usr/bin:/usr/local/bin',
         })
-        .that_requires("Staging::Deploy[dcm4chee-2.18.1-#{database_type_short}.zip]")
+        .that_requires("Staging::Deploy[dcm4chee-2.18.1-#{database['type_short']}.zip]")
         .that_requires('Class[dcm4chee::staging::jboss]')
         .that_requires('File[/usr/local/bin/validate_dcm4chee_jboss_installed.sh]')
       }
-      it { is_expected.to contain_file("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database_type_short}/bin/run.sh")
+      it { is_expected.to contain_file("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/bin/run.sh")
             .with({
               'ensure'  => 'file',
               'owner'   => 'dcm4chee',
               'group'   => 'dcm4chee',
               'source'  => '/opt/dcm4chee/staging/jboss-4.2.3.GA/bin/run.sh',
             })
-            .that_requires("Exec[/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database_type_short}/bin/install_jboss.sh]")
+            .that_requires("Exec[/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/bin/install_jboss.sh]")
       }
       it { is_expected.to contain_class('dcm4chee::staging::weasis')
-          .that_requires("File[/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database_type_short}/bin/run.sh]")
+          .that_requires("File[/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/bin/run.sh]")
+      }
+      it { is_expected.to contain_file("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/bin/run.conf")
+            .with({
+              'ensure' => 'absent',
+            })
+      }
+      it { is_expected.to contain_file("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/server/default/deploy/jboss-web.deployer/server.xml")
+            .with({
+              'ensure' => 'absent',
+            })
+      }
+      it { is_expected.to contain_file("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/server/default/deploy/pacs-#{database['configfile_short']}-ds.xml")
+            .with({
+              'ensure' => 'absent',
+            })
+      }
+      it { is_expected.to contain_file("/opt/dcm4chee/staging/dcm4chee-2.18.1-#{database['type_short']}/server/default/conf/jboss-log4j.xml")
+            .with({
+              'ensure' => 'absent',
+            })
       }
     end
   end


### PR DESCRIPTION
- staging ensures that all files managed by dcm4chee::config
  are absent in staging dcm4chee home directory
  this fixes bug of dcm4chee::install overriding changes made by
  config due to default files being present in staging home dir

its a workaround necessary because no proper dcm4chee package exists
