### PR TITLE
cause service restart on config change

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,10 +10,16 @@ class dcm4chee::config () {
   class { '::dcm4chee::config::jboss': } ->
   anchor { 'dcm4chee::config::end': }
   
+  # These are necessary to cause a service restart on config change
+  # Class['::dm4chee::config'] ~> Class['::dcm4chee::service']
+  # does not suffice due to submodules
+  Class[$database_class] ~> Anchor['dcm4chee::config::end']
+  Class['::dcm4chee::config::jboss'] ~> Anchor['dcm4chee::config::end']
+  
   if $::dcm4chee::weasis {
     class { '::dcm4chee::config::weasis': }
     Anchor['dcm4chee::config::begin'] ->
-    Class['::dcm4chee::config::weasis'] ->
+    Class['::dcm4chee::config::weasis'] ~>
     Anchor['dcm4chee::config::end']
 
     Class['::dcm4chee::config::jboss'] -> Class['::dcm4chee::config::weasis']

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -14,7 +14,9 @@ class dcm4chee::service () {
   }
 
   service { 'dcm4chee':
-    ensure => 'running',
-    enable => true,
+    ensure     => 'running',
+    enable     => true,
+    provider   => 'init',
+    hasrestart => true,
   }
 }

--- a/spec/classes/dcm4chee_config_spec.rb
+++ b/spec/classes/dcm4chee_config_spec.rb
@@ -17,13 +17,14 @@ describe 'dcm4chee::config', :type => :class do
       }
       it { is_expected.to contain_class("dcm4chee::config::#{database_type}")
             .that_comes_before('dcm4chee::config::jboss')
+            .that_notifies('Anchor[dcm4chee::config::end]')
       }
       it { is_expected.to contain_class('dcm4chee::config::jboss')
             .that_comes_before('dcm4chee::config::weasis')
-            .that_comes_before('Anchor[dcm4chee::config::end]')
+            .that_notifies('Anchor[dcm4chee::config::end]')
       }
       it { is_expected.to contain_class('dcm4chee::config::weasis')
-            .that_comes_before('Anchor[dcm4chee::config::end]')
+            .that_notifies('Anchor[dcm4chee::config::end]')
       }
       it { is_expected.to contain_anchor('dcm4chee::config::end') }
     end

--- a/spec/classes/dcm4chee_service_spec.rb
+++ b/spec/classes/dcm4chee_service_spec.rb
@@ -14,9 +14,11 @@ describe 'dcm4chee::service', :type => :class do
     }
     it { is_expected.to contain_service('dcm4chee')
           .only_with(
-            'name'   => 'dcm4chee',
-            'ensure' => 'running',
-            'enable' => 'true',
+            'name'       => 'dcm4chee',
+            'ensure'     => 'running',
+            'enable'     => 'true',
+            'provider'   => 'init',
+            'hasrestart' => 'true',
           )
     }
   end


### PR DESCRIPTION
- config submodules notify end anchor which causes
  notification of config ~> service
- explicitly set service provider to init
- use restart command of init.d script
