### PR TITLE
add define dcm4chee::default::entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ class role::pacs {
 
 #### Private classes
 
+### Defines
+
+#### Public Defines
+
+* `dcm4chee::default::entry`: Adds an entry to a dcm4chee configuration file (e.g., `/etc/default/dcm4chee`).
+
 ### Parameters
 
 All parameters are optional except where otherwise noted.
@@ -353,6 +359,34 @@ Defaults to [ 'patientID', 'studyUID', 'accessionNumber', 'seriesUID', 'objectUI
 Specifies the weasis [pacs-connector](https://github.com/nroduit/weasis-pacs-connector) property 'hosts.allow'.
 Valid options: an array.
 Default is [].
+
+#### dcm4chee::default::entry
+
+##### `value`
+
+*Required.* Provides the value of the managed parameter. Valid options: a
+string.
+
+##### `ensure`
+
+Determines whether the fragment should exist in the configuration file. Valid
+options: 'present', 'absent'. Default: 'present'.
+
+##### `param`
+
+Specifies a parameter to manage. Valid options: a string. Default: the '[title]'
+passed in your define.
+
+##### `order`
+
+Determines the ordering of your parameters in the configuration file
+(parameters with lower `order` values appear first.) Valid options: an integer
+or a string containing an integer. Default: '10'.
+
+##### `quote_char`
+
+Specifies a character to include before and after the specified value. Valid
+options: a string (usually a single or double quote). Default: (blank).
 
 ##Limitations
 

--- a/manifests/default/entry.pp
+++ b/manifests/default/entry.pp
@@ -1,0 +1,41 @@
+# See README.md for documentation.
+define dcm4chee::default::entry (
+  $value,
+  $ensure      = 'present',
+  $param       = $title,
+  $order       = '10',
+  $quote_char  = undef,
+) {
+  validate_string($value)
+
+  include '::dcm4chee'
+  $_config_file = '/etc/default/dcm4chee'
+
+  if ! $quote_char {
+  # lint:ignore:empty_string_assignment
+    $_quote_char = ''
+  # lint:endignore
+  } else {
+    $_quote_char = $quote_char
+  }
+
+  if ! defined(Concat[$_config_file]) {
+    concat { $_config_file:
+      owner          => 'root',
+      group          => 'root',
+      mode           => '0644',
+      ensure_newline => true,
+    }
+  }
+
+  $_content = inline_template('export <%= @param %>=<%= @_quote_char %><%= @value %><%= @_quote_char %>')
+  concat::fragment { "default-${name}":
+      ensure  => $ensure,
+      target  => $_config_file,
+      content => $_content,
+      order   => $order,
+      notify  => Class['dcm4chee::service'],
+  }
+
+}
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,9 @@ class dcm4chee::params {
   $server_java_opts = []
   $server_http_port = '8080'
   $server_ajp_connector_port = '8009'
+  # lint:ignore:single_quote_string_with_variables
   $server_log_file_path = '${jboss.server.log.dir}/server.log'
+  # lint:endignore
   $server_log_file_max_size = '10000KB'
   $server_log_append = false
   $server_log_max_backups  = '1'

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,7 @@
   "description": "Module for dcm4chee pacs configuration",
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.5.0 < 5.0.0"},
+    {"name":"puppetlabs/concat","version_requirement":">= 1.0.0 < 3.0.0"},
     {"name":"puppetlabs/mysql","version_requirement":">= 3.1.0 < 5.0.0"},
     {"name":"puppetlabs/postgresql","version_requirement":">= 4.0.0 < 5.0.0"},
     {"name":"nanliu/staging","version_requirement":">=1.0.3"}

--- a/spec/classes/dcm4chee_service_spec.rb
+++ b/spec/classes/dcm4chee_service_spec.rb
@@ -11,6 +11,8 @@ describe 'dcm4chee::service', :type => :class do
 
     it { is_expected.to contain_file('/etc/init.d/dcm4chee')
           .that_notifies('Service[dcm4chee]')
+          .with_content(/^JBOSS_HOME=\${JBOSS_HOME:-"\/opt\/dcm4chee\/dcm4chee-2\.18\.1-psql\/"/)
+          .with_content(/^JAVAPTH=\${JAVAPTH:-"\/usr\/lib\/jvm\/java-7-openjdk-amd64\/jre\/bin\/java"/)
     }
     it { is_expected.to contain_service('dcm4chee')
           .only_with(
@@ -32,6 +34,8 @@ describe 'dcm4chee::service', :type => :class do
 
     it { is_expected.to contain_file('/etc/init.d/dcm4chee')
           .that_notifies('Service[dcm4chee]')
+          .with_content(/^JBOSS_HOME=\${JBOSS_HOME:-"\/opt\/dcm4chee\/dcm4chee-2\.18\.1-psql\/"/)
+          .with_content(/^JAVAPTH=\${JAVAPTH:-"\/usr\/lib\/jvm\/java-7-openjdk-amd64\/jre\/bin\/java"/)
     }
     it { is_expected.to contain_service('dcm4chee')
           .only_with(
@@ -53,6 +57,8 @@ describe 'dcm4chee::service', :type => :class do
 
     it { is_expected.to contain_file('/etc/init.d/dcm4chee')
           .that_notifies('Service[dcm4chee]')
+          .with_content(/^JBOSS_HOME=\${JBOSS_HOME:-"\/opt\/dcm4chee\/dcm4chee-2\.18\.1-psql\/"/)
+          .with_content(/^JAVAPTH=\${JAVAPTH:-"\/usr\/lib\/jvm\/java-7-openjdk-amd64\/jre\/bin\/java"/)
     }
     it { is_expected.to contain_service('dcm4chee')
           .only_with(

--- a/spec/defines/default/entry_spec.rb
+++ b/spec/defines/default/entry_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+describe 'dcm4chee::default::entry', :type => :define do
+  let :pre_condition do
+    "class {'dcm4chee':
+        server_java_path => '/usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java',
+    }"
+  end
+  let :facts do
+    {
+      :osfamily       => 'Debian',
+      :concat_basedir => '/tmp',
+      :id             => 'root',
+      :path           => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+  let :title do
+    'LANG'
+  end
+  context 'no quotes' do
+    let :params do
+      {
+        'value' => 'es_ES.UTF-8',
+      }
+    end
+
+    it { is_expected.to contain_class('dcm4chee') }
+    it { is_expected.to contain_concat('/etc/default/dcm4chee').with({
+      'ensure' => 'present',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0644',
+    })
+    }
+    it { is_expected.to contain_concat__fragment('default-LANG').with_content(/export LANG=es_ES\.UTF-8/).with({
+      'ensure' => 'present',
+      'target' => '/etc/default/dcm4chee',
+      'order'  => '10',
+    })
+    .that_notifies('Class[dcm4chee::service]')
+    }
+  end
+  context 'quotes' do
+    let :params do
+      {
+        'value'      => 'es_ES.UTF-8',
+        'quote_char' => '"',
+      }
+    end
+
+    it { is_expected.to contain_class('dcm4chee') }
+    it { is_expected.to contain_concat('/etc/default/dcm4chee').with({
+      'ensure' => 'present',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0644',
+    })
+    }
+    it { is_expected.to contain_concat__fragment('default-LANG').with_content(/export LANG="es_ES\.UTF-8"/).with({
+      'ensure' => 'present',
+      'target' => '/etc/default/dcm4chee',
+      'order'  => '10',
+    })
+    .that_notifies('Class[dcm4chee::service]')
+    }
+  end
+  context 'ensure absent' do
+    let :params do
+      {
+        'value'  => 'es_ES.UTF-8',
+        'ensure' => 'absent',
+      }
+    end
+
+    it { is_expected.to contain_class('dcm4chee') }
+    it { is_expected.to contain_concat('/etc/default/dcm4chee').with({
+      'ensure' => 'present',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0644',
+    })
+    }
+    it { is_expected.to contain_concat__fragment('default-LANG').with_content(/export LANG=es_ES\.UTF-8/).with({
+      'ensure' => 'absent',
+      'target' => '/etc/default/dcm4chee',
+    })
+    .that_notifies('Class[dcm4chee::service]')
+    }
+  end
+  context 'order' do
+    let :params do
+      {
+        'param' => 'BAR',
+        'value' => 'es_ES.UTF-8',
+        'order' => '20',
+      }
+    end
+
+    it { is_expected.to contain_class('dcm4chee') }
+    it { is_expected.to contain_concat('/etc/default/dcm4chee').with({
+      'ensure' => 'present',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0644',
+    })
+    }
+    it { is_expected.to contain_concat__fragment('default-LANG').with_content(/export BAR=es_ES\.UTF-8/).with({
+      'ensure' => 'present',
+      'target' => '/etc/default/dcm4chee',
+      'order'  => '20',
+    })
+    .that_notifies('Class[dcm4chee::service]')
+    }
+  end
+end

--- a/templates/etc/init.d/dcm4chee.erb
+++ b/templates/etc/init.d/dcm4chee.erb
@@ -40,6 +40,10 @@ if [ -z "`echo $PATH | grep $JAVAPTH`" ]; then
   export PATH=$PATH:$JAVAPTH
 fi
 
+if [ -r "/etc/default/dcm4chee" ]; then
+  . "/etc/default/dcm4chee"
+fi
+
 # Define LSB functions.
 . /lib/lsb/init-functions
 


### PR DESCRIPTION
define dcm4chee::default::entry adds concat for
/etc/default/dcm4chee
and concat::fragment to ensure key/value pairs are
present/absent

this enables adding line like 'export LANG="es_ES.UTF-8"'
which helps in configuring a consistent environment
for the service to run in.

can prevent issue "umlaut becomes question mark in roles and groups"
https://groups.google.com/forum/#!searchin/dcm4che/umlaut%7Csort:relevance/dcm4che/pNogBT4EBcU/086uO1YUAgAJ

* add define default::entry which notifies dcm4chee::service
* read /etc/default/dcm4chee in init.d/dcm4chee
* add concat dependency to module
* test service for existence of JBOSS_HOME
* test service for existence of JAVAPTH
* ignore puppet lint on params single quoted string